### PR TITLE
Fix factory data erase shell command

### DIFF
--- a/subsys/factory_data/factory_data_shell.c
+++ b/subsys/factory_data/factory_data_shell.c
@@ -103,8 +103,7 @@ static int cmd_erase(const struct shell *shell_ptr, size_t argc, char *argv[])
 
 	ret = factory_data_init();
 	if (ret) {
-		shell_error(shell_ptr, "Failed to initialize: %d", ret);
-		return -EIO;
+		shell_warn(shell_ptr, "Failed to initialize (%d), but continue with erasing", ret);
 	}
 
 	ret = factory_data_erase();


### PR DESCRIPTION
Without this, a corrupted factory data flash area could not be deleted by the shell command 'factory_data erase' due to the initialization code failing in the first place.

On the next Zephyr update, this commit should be squashed into 5db2c73f5db428fbf9d96073fc91d426d145d1d4 ([lb toup] factory data: Add new subsystem).