### PR TITLE
[sg fromtree dirty] drivers: sensor: voltage_divider: Improves resolution to sub-millivolt

### DIFF
--- a/drivers/sensor/voltage_divider/voltage.c
+++ b/drivers/sensor/voltage_divider/voltage.c
@@ -6,6 +6,8 @@
 
 #define DT_DRV_COMPAT voltage_divider
 
+#include <inttypes.h>
+
 #include <zephyr/drivers/adc.h>
 #include <zephyr/drivers/adc/voltage_divider.h>
 #include <zephyr/drivers/gpio.h>
@@ -62,7 +64,6 @@ static int get(const struct device *dev, enum sensor_channel chan, struct sensor
 	const struct voltage_config *config = dev->config;
 	struct voltage_data *data = dev->data;
 	int32_t raw_val;
-	int32_t v_mv;
 	int ret;
 
 	__ASSERT_NO_MSG(val != NULL);
@@ -77,23 +78,20 @@ static int get(const struct device *dev, enum sensor_channel chan, struct sensor
 		raw_val = data->raw;
 	}
 
-	ret = adc_raw_to_millivolts_dt(&config->voltage.port, &raw_val);
+	ret = adc_raw_to_microvolts_dt(&config->voltage.port, &raw_val);
 	if (ret != 0) {
-		LOG_ERR("raw_to_mv: %d", ret);
+		LOG_ERR("raw_to_uv: %d", ret);
 		return ret;
 	}
 
-	v_mv = raw_val;
+	int64_t voltage_uv = raw_val;
 
 	/* Note if full_ohms is not specified then unscaled voltage is returned */
-	(void)voltage_divider_scale_dt(&config->voltage, &v_mv);
+	(void)voltage_divider_scale64_dt(&config->voltage, &voltage_uv);
 
-	LOG_DBG("%d of %d, %dmV, voltage:%dmV", data->raw,
-		(1 << data->sequence.resolution) - 1, raw_val, v_mv);
-	val->val1 = v_mv / 1000;
-	val->val2 = (v_mv * 1000) % 1000000;
-
-	return ret;
+	LOG_DBG("%" PRIu16 " of %lu, %" PRIi32 "uV, voltage:%" PRIi64 "uV", data->raw,
+		BIT_MASK(data->sequence.resolution), raw_val, voltage_uv);
+	return sensor_value_from_micro(val, voltage_uv);
 }
 
 static DEVICE_API(sensor, voltage_api) = {

--- a/include/zephyr/drivers/adc/voltage_divider.h
+++ b/include/zephyr/drivers/adc/voltage_divider.h
@@ -4,14 +4,37 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for extended API of Voltage Divider
+ * @ingroup adc_voltage_divider_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_ADC_VOLTAGE_DIVIDER_H_
 #define ZEPHYR_INCLUDE_DRIVERS_ADC_VOLTAGE_DIVIDER_H_
 
 #include <zephyr/drivers/adc.h>
 
+/**
+ * @brief Voltage Divider
+ * @defgroup adc_voltage_divider_interface Voltage Divider
+ * @ingroup adc_interface_ext
+ * @{
+ */
+
+/**
+ * @brief Voltage divider DT struct.
+ *
+ * This stores information about a voltage divider obtained from Devicetree.
+ *
+ * @see VOLTAGE_DIVIDER_DT_SPEC_GET
+ */
 struct voltage_divider_dt_spec {
+	/** ADC channel info */
 	const struct adc_dt_spec port;
+	/** Full resistance in ohms */
 	uint32_t full_ohms;
+	/** Output resistance in ohms */
 	uint32_t output_ohms;
 };
 
@@ -33,7 +56,7 @@ struct voltage_divider_dt_spec {
 	}
 
 /**
- * @brief Calculates the actual voltage from the measured voltage
+ * @brief Calculates the actual voltage from a measured voltage
  *
  * @param[in] spec voltage divider specification from Devicetree.
  * @param[in,out] v_to_v Pointer to the measured voltage on input, and the
@@ -55,5 +78,33 @@ static inline int voltage_divider_scale_dt(const struct voltage_divider_dt_spec 
 
 	return 0;
 }
+
+/**
+ * @brief Calculates the actual voltage from a measured voltage for 64-bit values
+ *
+ * @see voltage_divider_scale_dt()
+ *
+ * @param[in] spec voltage divider specification from Devicetree.
+ * @param[in,out] v_to_v Pointer to the measured voltage on input, and the
+ * corresponding scaled voltage value on output.
+ *
+ * @retval 0 on success
+ * @retval -ENOTSUP if "full_ohms" is not specified
+ */
+static inline int voltage_divider_scale64_dt(const struct voltage_divider_dt_spec *spec,
+					     int64_t *v_to_v)
+{
+	/* cannot be scaled if "full_ohms" is not specified */
+	if (spec->full_ohms == 0) {
+		return -ENOTSUP;
+	}
+
+	/* voltage scaled by voltage divider values using DT binding */
+	*v_to_v = *v_to_v * spec->full_ohms / spec->output_ohms;
+
+	return 0;
+}
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_ADC_VOLTAGE_DIVIDER_H_ */


### PR DESCRIPTION
The calculation of the sensor value uses the intermediate value of the function `adc_raw_to_microvolts_dt`. This results in a sensor value with a resolution that is not below `voltage-divider-scaling` millivolts which can be too rough for some applications.

Using `adc_raw_to_microvolts_dt` and 64-bit-based scaling improves the resulting voltage resolution.
Therefore, the public function `voltage_divider_scale64_dt()` is introduced, which performs the same as `voltage_divider_scale_dt()`. This decision does not affect implementations that use the current 32-bit implementation of `voltage_divider_scale_dt()`.

Signed-off-by: Stefan Schwendeler <Stefan.Schwendeler@husqvarnagroup.com>

Dirty: cherry pick has a merge conflict with some comments (cherry picked from commit c787220f4834a5b784855f554685f4a7a4107dbe)