### PR TITLE
[sg fromtree dirty] net: shell: quiet ping with statistics

### DIFF
--- a/subsys/net/lib/shell/ping.c
+++ b/subsys/net/lib/shell/ping.c
@@ -12,6 +12,7 @@ LOG_MODULE_DECLARE(net_shell);
 #include <stdio.h>
 #include <zephyr/random/random.h>
 #include <zephyr/net/icmp.h>
+#include <zephyr/net/net_linkaddr.h>
 
 #include "net_shell_private.h"
 
@@ -38,73 +39,98 @@ static struct ping_context {
 	uint32_t sequence;
 	uint16_t payload_size;
 	uint8_t tos;
+	bool quiet;
 	int priority;
+	struct ping_stats {
+		uint64_t cycle_sum;
+		uint32_t pkt_sent;
+		uint32_t pkt_recv;
+		uint32_t rtt_count;
+		uint32_t rtt_min;
+		uint32_t rtt_max;
+	} stats;
 } ping_ctx;
 
 static void ping_done(struct ping_context *ctx);
+static int handle_echo_reply_common(struct net_pkt *pkt, uint16_t sequence,
+				    uint16_t bytes, const char *src, const char *dst,
+				    uint8_t ttl);
+
+#ifdef CONFIG_FPU
+#define PING_PRI_MSEC             "%.2f"
+#define PING_CYCLES_MSEC(_cycles) ((double)((uint32_t)k_cyc_to_ns_floor64(_cycles) / 1e6f))
+#else
+#define PING_PRI_MSEC             "%u"
+#define PING_CYCLES_MSEC(_cycles) ((uint32_t)k_cyc_to_ns_floor64(_cycles) / 1000000)
+#endif
+
+/** Print the ping statistics.
+ *
+ * @param ctx The ping context
+ */
+static void stats_print(struct ping_context *ctx)
+{
+	uint_fast8_t pkt_loss_percent = 100;
+
+	PR_SHELL(ctx->sh, "--- ping statistics ---\n");
+
+	if (ctx->stats.pkt_sent > 0) {
+		if (ctx->stats.pkt_recv < ctx->stats.pkt_sent) {
+			pkt_loss_percent = (ctx->stats.pkt_sent - ctx->stats.pkt_recv) * 100 /
+					   ctx->stats.pkt_sent;
+		} else {
+			pkt_loss_percent = 0;
+		}
+	}
+
+	PR_SHELL(ctx->sh, "%u packets transmitted, %u received, %u%% packet loss\n",
+		 ctx->stats.pkt_sent, ctx->stats.pkt_recv, pkt_loss_percent);
+
+	if (ctx->stats.rtt_count > 0) {
+		/* rtt = round-trip-time */
+		PR_SHELL(ctx->sh,
+			 "rtt min/avg/max = " PING_PRI_MSEC "/" PING_PRI_MSEC "/" PING_PRI_MSEC
+			 " ms\n",
+			 PING_CYCLES_MSEC(ctx->stats.rtt_min),
+			 PING_CYCLES_MSEC(ctx->stats.cycle_sum / ctx->stats.rtt_count),
+			 PING_CYCLES_MSEC(ctx->stats.rtt_max));
+	}
+}
+
+/** Update ping statistics.
+ *
+ * @param ctx The ping context.
+ * @param cycles The round-trip time in ticks.
+ */
+static void stats_update(struct ping_context *ctx, uint32_t cycles)
+{
+	ctx->stats.rtt_count++;
+	ctx->stats.cycle_sum += cycles;
+	ctx->stats.rtt_min = MIN(ctx->stats.rtt_min, cycles);
+	ctx->stats.rtt_max = MAX(ctx->stats.rtt_max, cycles);
+}
 
 #if defined(CONFIG_NET_NATIVE_IPV6)
 
-static int handle_ipv6_echo_reply(struct net_icmp_ctx *ctx,
-				  struct net_pkt *pkt,
-				  struct net_icmp_ip_hdr *hdr,
-				  struct net_icmp_hdr *icmp_hdr,
+static int handle_ipv6_echo_reply(struct net_icmp_ctx *ctx, struct net_pkt *pkt,
+				  struct net_icmp_ip_hdr *hdr, struct net_icmp_hdr *icmp_hdr,
 				  void *user_data)
 {
-	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(icmp_access,
-					      struct net_icmpv6_echo_req);
+	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(icmp_access, struct net_icmpv6_echo_req);
 	struct net_ipv6_hdr *ip_hdr = hdr->ipv6;
 	struct net_icmpv6_echo_req *icmp_echo;
-	uint32_t cycles;
-	char time_buf[16] = { 0 };
 
-	icmp_echo = (struct net_icmpv6_echo_req *)net_pkt_get_data(pkt,
-								&icmp_access);
+	icmp_echo = (struct net_icmpv6_echo_req *)net_pkt_get_data(pkt, &icmp_access);
 	if (icmp_echo == NULL) {
 		return -EIO;
 	}
-
 	net_pkt_skip(pkt, sizeof(*icmp_echo));
 
-	if (net_pkt_remaining_data(pkt) >= sizeof(uint32_t)) {
-		if (net_pkt_read_be32(pkt, &cycles)) {
-			return -EIO;
-		}
-
-		cycles = k_cycle_get_32() - cycles;
-
-		snprintf(time_buf, sizeof(time_buf),
-#ifdef CONFIG_FPU
-			 "time=%.2f ms",
-			 (double)((uint32_t)k_cyc_to_ns_floor64(cycles) / 1000000.f)
-#else
-			 "time=%d ms",
-			 ((uint32_t)k_cyc_to_ns_floor64(cycles) / 1000000)
-#endif
-			);
-	}
-
-	PR_SHELL(ping_ctx.sh, "%d bytes from %s to %s: icmp_seq=%d ttl=%d "
-#ifdef CONFIG_IEEE802154
-		 "rssi=%d "
-#endif
-		 "%s\n",
-		 ntohs(ip_hdr->len) - net_pkt_ipv6_ext_len(pkt) -
-								NET_ICMPH_LEN,
-		 net_sprint_ipv6_addr(&ip_hdr->src),
-		 net_sprint_ipv6_addr(&ip_hdr->dst),
-		 ntohs(icmp_echo->sequence),
-		 ip_hdr->hop_limit,
-#ifdef CONFIG_IEEE802154
-		 net_pkt_ieee802154_rssi_dbm(pkt),
-#endif
-		 time_buf);
-
-	if (ntohs(icmp_echo->sequence) == ping_ctx.count) {
-		ping_done(&ping_ctx);
-	}
-
-	return 0;
+	return handle_echo_reply_common(pkt, ntohs(icmp_echo->sequence),
+					ntohs(ip_hdr->len) - net_pkt_ipv6_ext_len(pkt) -
+						NET_ICMPH_LEN,
+					net_sprint_ipv6_addr(&ip_hdr->src),
+					net_sprint_ipv6_addr(&ip_hdr->dst), ip_hdr->hop_limit);
 }
 #else
 static int handle_ipv6_echo_reply(struct net_icmp_ctx *ctx,
@@ -134,9 +160,7 @@ static int handle_ipv4_echo_reply(struct net_icmp_ctx *ctx,
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(icmp_access,
 					      struct net_icmpv4_echo_req);
 	struct net_ipv4_hdr *ip_hdr = hdr->ipv4;
-	uint32_t cycles;
 	struct net_icmpv4_echo_req *icmp_echo;
-	char time_buf[16] = { 0 };
 
 	icmp_echo = (struct net_icmpv4_echo_req *)net_pkt_get_data(pkt,
 								&icmp_access);
@@ -146,39 +170,11 @@ static int handle_ipv4_echo_reply(struct net_icmp_ctx *ctx,
 
 	net_pkt_skip(pkt, sizeof(*icmp_echo));
 
-	if (net_pkt_remaining_data(pkt) >= sizeof(uint32_t)) {
-		if (net_pkt_read_be32(pkt, &cycles)) {
-			return -EIO;
-		}
-
-		cycles = k_cycle_get_32() - cycles;
-
-		snprintf(time_buf, sizeof(time_buf),
-#ifdef CONFIG_FPU
-			 "time=%.2f ms",
-			 (double)((uint32_t)k_cyc_to_ns_floor64(cycles) / 1000000.f)
-#else
-			 "time=%d ms",
-			 ((uint32_t)k_cyc_to_ns_floor64(cycles) / 1000000)
-#endif
-			);
-	}
-
-	PR_SHELL(ping_ctx.sh, "%d bytes from %s to %s: icmp_seq=%d ttl=%d "
-		 "%s\n",
-		 ntohs(ip_hdr->len) - net_pkt_ipv6_ext_len(pkt) -
-								NET_ICMPH_LEN,
-		 net_sprint_ipv4_addr(&ip_hdr->src),
-		 net_sprint_ipv4_addr(&ip_hdr->dst),
-		 ntohs(icmp_echo->sequence),
-		 ip_hdr->ttl,
-		 time_buf);
-
-	if (ntohs(icmp_echo->sequence) == ping_ctx.count) {
-		ping_done(&ping_ctx);
-	}
-
-	return 0;
+	return handle_echo_reply_common(pkt, ntohs(icmp_echo->sequence),
+					ntohs(ip_hdr->len) - net_pkt_ipv6_ext_len(pkt) -
+						NET_ICMPH_LEN,
+					net_sprint_ipv4_addr(&ip_hdr->src),
+					net_sprint_ipv4_addr(&ip_hdr->dst), ip_hdr->ttl);
 }
 #else
 static int handle_ipv4_echo_reply(struct net_icmp_ctx *ctx,
@@ -196,6 +192,62 @@ static int handle_ipv4_echo_reply(struct net_icmp_ctx *ctx,
 	return -ENOTSUP;
 }
 #endif /* CONFIG_NET_IPV4 */
+
+#if defined(CONFIG_NET_IPV4) || defined(CONFIG_NET_IPV6)
+
+/**	Calculating the round-trip time and printing the result.
+ *
+ * @param pkt The packet containing the echo reply
+ * @param sequence Sequence number
+ * @param bytes Ping data length
+ * @param src Source address
+ * @param dst Destination address
+ * @param ttl Time-to-live
+ * @return 0 on success, negative error code on failure
+ */
+static int handle_echo_reply_common(struct net_pkt *pkt, uint16_t sequence, uint16_t bytes,
+				    const char *src, const char *dst, uint8_t ttl)
+{
+	uint32_t cycles = 0;
+	char time_buf[16] = {0};
+
+	if (net_pkt_remaining_data(pkt) >= sizeof(uint32_t)) {
+		if (net_pkt_read_be32(pkt, &cycles)) {
+			return -EIO;
+		}
+
+		cycles = k_cycle_get_32() - cycles;
+		if (!ping_ctx.quiet) {
+			snprintf(time_buf, sizeof(time_buf), "time=" PING_PRI_MSEC " ms",
+				 PING_CYCLES_MSEC(cycles));
+		}
+		stats_update(&ping_ctx, cycles);
+	}
+	ping_ctx.stats.pkt_recv++;
+
+	if (!ping_ctx.quiet) {
+#ifdef CONFIG_IEEE802154
+		char rssi_buf[16] = {0};
+		struct net_linkaddr *link_addr = net_if_get_link_addr(pkt->iface);
+
+		if (link_addr && link_addr->type == NET_LINK_IEEE802154) {
+			snprintf(rssi_buf, sizeof(rssi_buf), "rssi=%d ",
+				 net_pkt_ieee802154_rssi_dbm(pkt));
+		}
+#else
+		const char rssi_buf[1] = {0};
+#endif
+		PR_SHELL(ping_ctx.sh, "%d bytes from %s to %s: icmp_seq=%u ttl=%u %s%s\n", bytes,
+			 src, dst, sequence, ttl, rssi_buf, time_buf);
+	}
+
+	if (sequence == ping_ctx.count) {
+		ping_done(&ping_ctx);
+	}
+
+	return 0;
+}
+#endif
 
 static int parse_arg(size_t *i, size_t argc, char *argv[])
 {
@@ -232,6 +284,8 @@ static void ping_cleanup(struct ping_context *ctx)
 {
 	(void)net_icmp_cleanup_ctx(&ctx->icmp);
 	shell_set_bypass(ctx->sh, NULL);
+
+	stats_print(ctx);
 }
 
 static void ping_done(struct ping_context *ctx)
@@ -254,7 +308,9 @@ static void ping_work(struct k_work *work)
 	ctx->sequence++;
 
 	if (ctx->sequence > ctx->count) {
-		PR_INFO("Ping timeout\n");
+		if (!ctx->quiet) {
+			PR_INFO("Ping timeout\n");
+		}
 		ping_done(ctx);
 		return;
 	}
@@ -264,6 +320,8 @@ static void ping_work(struct k_work *work)
 	} else {
 		k_work_reschedule(&ctx->work, K_SECONDS(2));
 	}
+
+	ctx->stats.pkt_sent++;
 
 	params.identifier = sys_rand32_get();
 	params.sequence = ctx->sequence;
@@ -278,7 +336,8 @@ static void ping_work(struct k_work *work)
 						 &params,
 						 ctx);
 	if (ret != 0) {
-		PR_WARNING("Failed to send ping, err: %d", ret);
+		PR_WARNING("Failed to send ping, err: %d\n", ret);
+		ctx->stats.pkt_sent--;
 		ping_done(ctx);
 		return;
 	}
@@ -368,6 +427,7 @@ static int cmd_net_ping(const struct shell *sh, size_t argc, char *argv[])
 	int tos = 0;
 	int payload_size = 4;
 	int priority = -1;
+	bool quiet = false;
 	int ret;
 
 	for (size_t i = 1; i < argc; ++i) {
@@ -430,6 +490,10 @@ static int cmd_net_ping(const struct shell *sh, size_t argc, char *argv[])
 
 			break;
 
+		case 'q':
+			quiet = true;
+			break;
+
 		default:
 			PR_WARNING("Unrecognized argument: %s\n", argv[i]);
 			return -ENOEXEC;
@@ -451,6 +515,8 @@ static int cmd_net_ping(const struct shell *sh, size_t argc, char *argv[])
 	ping_ctx.priority = priority;
 	ping_ctx.tos = tos;
 	ping_ctx.payload_size = payload_size;
+	ping_ctx.stats = (struct ping_stats){.rtt_min = UINT32_MAX};
+	ping_ctx.quiet = quiet;
 
 	if (IS_ENABLED(CONFIG_NET_IPV6) &&
 	    net_addr_pton(AF_INET6, host, &ping_ctx.addr6.sin6_addr) == 0) {
@@ -488,14 +554,14 @@ static int cmd_net_ping(const struct shell *sh, size_t argc, char *argv[])
 #endif
 }
 
-SHELL_STATIC_SUBCMD_SET_CREATE(net_cmd_ping,
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	net_cmd_ping,
 	SHELL_CMD(--help, NULL,
-		  "'net ping [-c count] [-i interval ms] [-I <iface index>] "
-		  "[-Q tos] [-s payload size] [-p priority] <host>' "
+		  "'net ping [-c <count>] [-i <interval ms>] [-I <iface index>] "
+		  "[-Q <tos>] [-s <payload size>] [-p <priority>] [-q] <host>' "
 		  "Send ICMPv4 or ICMPv6 Echo-Request to a network host.",
 		  cmd_net_ping),
-	SHELL_SUBCMD_SET_END
-);
+	SHELL_SUBCMD_SET_END);
 
 SHELL_SUBCMD_ADD((net), ping, &net_cmd_ping,
 		 "Ping a network host.",

--- a/subsys/net/lib/shell/ping.c
+++ b/subsys/net/lib/shell/ping.c
@@ -14,6 +14,9 @@ LOG_MODULE_DECLARE(net_shell);
 #include <zephyr/net/icmp.h>
 #include <zephyr/net/net_linkaddr.h>
 
+#ifdef CONFIG_LEMONBEAT_RADIO
+#include "net/lb_net_pkt.h"
+#endif
 #include "net_shell_private.h"
 
 #include "../ip/icmpv6.h"
@@ -52,9 +55,8 @@ static struct ping_context {
 } ping_ctx;
 
 static void ping_done(struct ping_context *ctx);
-static int handle_echo_reply_common(struct net_pkt *pkt, uint16_t sequence,
-				    uint16_t bytes, const char *src, const char *dst,
-				    uint8_t ttl);
+static int handle_echo_reply_common(struct net_pkt *pkt, uint16_t sequence, uint16_t bytes,
+				    const char *src, const char *dst, uint8_t ttl);
 
 #ifdef CONFIG_FPU
 #define PING_PRI_MSEC             "%.2f"
@@ -195,6 +197,39 @@ static int handle_ipv4_echo_reply(struct net_icmp_ctx *ctx,
 
 #if defined(CONFIG_NET_IPV4) || defined(CONFIG_NET_IPV6)
 
+/** Get RSSI from net packet.
+ *
+ * @param pkt The packet containing the echo reply
+ * @param[out] rssi	Pointer to store the received signal strength indicator (RSSI) in dBm
+ * @retval 0 on success
+ * @retval <0 on failure
+ */
+static int rssi_dbm_get(struct net_pkt *pkt, int16_t *rssi)
+{
+	struct net_linkaddr *link_addr = net_if_get_link_addr(pkt->iface);
+
+	if (link_addr) {
+		switch (link_addr->type) {
+#ifdef CONFIG_IEEE802154
+		case NET_LINK_IEEE802154:
+			*rssi = net_pkt_ieee802154_rssi_dbm(pkt);
+			return 0;
+#endif
+		case NET_LINK_UNKNOWN:
+#ifdef CONFIG_NET_L2_LEMONBEAT
+			if (net_if_l2(pkt->iface) == &NET_L2_GET_NAME(LEMONBEAT)) {
+				*rssi = net_pkt_cb_lb_get_rx_rssi_dbm(pkt);
+				return 0;
+			}
+#endif
+			break;
+		default:
+			break;
+		}
+	}
+	return -ENOTSUP;
+}
+
 /**	Calculating the round-trip time and printing the result.
  *
  * @param pkt The packet containing the echo reply
@@ -226,17 +261,13 @@ static int handle_echo_reply_common(struct net_pkt *pkt, uint16_t sequence, uint
 	ping_ctx.stats.pkt_recv++;
 
 	if (!ping_ctx.quiet) {
-#ifdef CONFIG_IEEE802154
+		int16_t rssi_dbm;
 		char rssi_buf[16] = {0};
-		struct net_linkaddr *link_addr = net_if_get_link_addr(pkt->iface);
 
-		if (link_addr && link_addr->type == NET_LINK_IEEE802154) {
-			snprintf(rssi_buf, sizeof(rssi_buf), "rssi=%d ",
-				 net_pkt_ieee802154_rssi_dbm(pkt));
+		if (rssi_dbm_get(pkt, &rssi_dbm) == 0) {
+			snprintf(rssi_buf, sizeof(rssi_buf), "rssi=%d ", rssi_dbm);
 		}
-#else
-		const char rssi_buf[1] = {0};
-#endif
+
 		PR_SHELL(ping_ctx.sh, "%d bytes from %s to %s: icmp_seq=%u ttl=%u %s%s\n", bytes,
 			 src, dst, sequence, ttl, rssi_buf, time_buf);
 	}


### PR DESCRIPTION
See Zephyr upstream pull request 
https://github.com/zephyrproject-rtos/zephyr/pull/110800

Due to an upcoming merge conflict with Zephyr 4.4,  this commit is marked as dirty.

The PR includes an extension for Lemonbeat that print the RSSI of the response packet.